### PR TITLE
Apply Minimal Mistakes theme and import legacy content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
- gem 'github-pages', group: :jekyll_plugins
+gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-include-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-include-cache
 
 BUNDLED WITH
    2.6.7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Usama Sadiq Portfolio
 
-This repository contains my personal portfolio powered by [Jekyll](https://jekyllrb.com/). It is ready for hosting on GitHub Pages and provides a structure for both project pages and blog posts.
+This repository contains my personal portfolio powered by [Jekyll](https://jekyllrb.com/) using the [Minimal Mistakes](https://github.com/mmistakes/minimal-mistakes) theme in dark mode by default. It is ready for hosting on GitHub Pages and provides a structure for both project pages and blog posts.
 
 ## Development
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,10 +6,12 @@ baseurl: ""
 url: "https://usamasadiq.github.io"
 
 # Build settings
-remote_theme: jekyll/minima
+remote_theme: mmistakes/minimal-mistakes
+minimal_mistakes_skin: "dark"
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-include-cache
 
 collections:
   projects:

--- a/_posts/2024-01-01-welcome.md
+++ b/_posts/2024-01-01-welcome.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: single
 title: "Welcome to my blog"
 ---
 

--- a/_projects/edx-scraper.md
+++ b/_projects/edx-scraper.md
@@ -1,0 +1,6 @@
+---
+layout: project
+title: edX Institution Scraper
+---
+
+This project includes a Python script that scrapes edX partner pages to collect the first course offered by each institution. It uses Selenium WebDriver for dynamic content and writes results incrementally to a CSV file. Detailed instructions and usage notes are available in the legacy page `legacy_projects/scrappers/edx_scrapper.html`.

--- a/_projects/flashmaster.md
+++ b/_projects/flashmaster.md
@@ -3,4 +3,4 @@ layout: project
 title: Flashmaster
 ---
 
-Details about the Flashmaster project will appear here.
+Flashmaster is a small flashcard learning application built with React and TypeScript. It loads quiz data from JSON files and lets you practice topics such as Python, JavaScript, React and more. The legacy implementation can be found in the `legacy_projects/flashmaster` folder.

--- a/_projects/hilteks.md
+++ b/_projects/hilteks.md
@@ -1,0 +1,6 @@
+---
+layout: project
+title: Hilteks International
+---
+
+Hilteks International is a global leader in textile and chemical innovations providing sustainable solutions. The legacy HTML version showcases sections on products like high-quality yarn, fabric rolls and protective textiles as well as services for R&D consultation, global logistics and quality assurance. See the original page in `legacy_projects/hilteks.html`.

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 title: Blog
 ---
 

--- a/index.md
+++ b/index.md
@@ -4,6 +4,17 @@ title: "Usama Sadiq"
 ---
 
 Welcome to my personal portfolio built with [Jekyll](https://jekyllrb.com/).
-Here you'll find details about my work, projects and future blog posts.
 
-Checkout the [Projects](/projects/) page to see a showcase of my work or head over to the [Blog](/blog/) section for updates.
+## About Me
+
+Hi! I'm Usama Sadiq — a passionate Backend Developer and DevOps Engineer who loves automating things, building scalable systems, and solving real-world problems through code. I'm currently working at Arbisoft, where I contribute to the edX project, dabble with AWS magic, and occasionally geek out over cool tech stuff. When I'm not knee-deep in Python or battling with Docker containers, you'll probably find me lost in a good book, binge-watching anime, or sketching out ideas for my next side project.
+
+## Education
+
+- **Bachelor of Science in Computer Science (BSCS)**, Information Technology University (ITU) Lahore, Pakistan, 2014–2018 — Graduated with honors focusing on software engineering, algorithms, and cloud computing technologies.
+
+## Skills & Expertise
+
+I have 6+ years of experience working with Python, Django, React, MySQL, Docker, AWS, Kubernetes, and CI/CD technologies. I specialize in building scalable backend systems and optimizing infrastructure. I am responsible for leading migrations, resolving high-priority issues, and developing tools that improve the developer experience.
+
+Check out the [Projects](/projects/) page to see a showcase of my work or head over to the [Blog](/blog/) section for updates.

--- a/projects/index.md
+++ b/projects/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 title: Projects
 ---
 


### PR DESCRIPTION
## Summary
- set Minimal Mistakes theme with dark skin
- add jekyll-include-cache dependency
- import About Me and project info from legacy site
- update blog and projects pages to use default layout
- create project pages for Hilteks International and edX scraper

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_688101a7364c832e9884ed8ac8bf2288